### PR TITLE
Set organism default value

### DIFF
--- a/snaptron_query/app/components.py
+++ b/snaptron_query/app/components.py
@@ -27,7 +27,8 @@ def get_dropdown_compilation(component_id):
     """Wrapper function to retrieve the dropdown component"""
     return html.Div([
         dbc.Label(gs.drop_compilation, className='fw-bold'),
-        dcc.Dropdown(id=component_id, options=gs.compilation_names_dict)
+        dcc.Dropdown(id=component_id, options=gs.compilation_names_dict,
+                     value=gs.compilation_srav3h)
     ], className="dbc",
     )
 


### PR DESCRIPTION
This PR sets the compilation dropdown with a default value of SRAV3h per request. Previously there was no default value. This will affect both JIQ and GEX compilations.


<img width="394" alt="Screenshot 2024-06-05 at 4 15 51 PM" src="https://github.com/ssec-jhu/snaptron-query/assets/1739327/4b0f8036-9884-4d84-9a8a-f0cfdb137714">
