### PR TITLE
helm tag update: beta-2-f9c12b5

### DIFF
--- a/snapmine/values_prod.yaml
+++ b/snapmine/values_prod.yaml
@@ -1,7 +1,7 @@
 image:
   repository: containers.repo.sciserver.org/ssec-snaptron/snapmine
   pullPolicy: Always
-  tag: beta-1-8dad4a7
+  tag: beta-2-f9c12b5
   args:
     - 'snaptron_query.app.main_dash_app:server'
     - '--workers=3' # suggested workers is 2*Core+1 https://docs.gunicorn.org/en/latest/design.html#how-many-workers


### PR DESCRIPTION
updating helm chart with tag beta-2-f9c12b5 of latest image deployed