### PR TITLE
Fixing data headers and strings per request

### DIFF
--- a/snaptron_query/app/assets/graph_update_geq.js
+++ b/snaptron_query/app/assets/graph_update_geq.js
@@ -20,7 +20,7 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
                 }
 
                 if (log_x) {
-                    newFigure.data[0].x = data.map(item => item['log2_norm_count']); //gs.table_geq_col_log_2_norm
+                    newFigure.data[0].x = data.map(item => item['log2_normalized_count']); //gs.table_geq_col_log_2_norm
                     newFigure.layout.xaxis.title = "Log\u2082(count+0.01)"; //gs.geq_log_count
                     newFigure.data[0].hovertemplate = "Log(count)=%{x}<br>count=%{y}<extra></extra>"
                 } else {
@@ -68,9 +68,10 @@ window.dash_clientside = Object.assign({}, window.dash_clientside, {
                     newFigure.data.forEach(trace => {
                         trace.customdata = data.map(item => [item['rail_id']])
                         if (trace.name === "Raw Count") {
-                            trace.y = data.map(item => item['log2_raw'])
-                        } else {
-                            trace.y = data.map(item => item['log2_norm_count'])
+                            trace.y = data.map(item => item['log2_raw_count'])
+                        }
+                        else{
+                            trace.y = data.map(item => item['log2_normalized_count'])
                         }
                     });
                     newFigure.layout.yaxis.title = "Log\u2082(Gene Expression Count+0.01)"

--- a/snaptron_query/app/callback_common.py
+++ b/snaptron_query/app/callback_common.py
@@ -1,5 +1,7 @@
 from datetime import datetime
-from dash import no_update
+
+import pandas as pd
+from dash import no_update, dcc
 
 from snaptron_query.app import global_strings as gs, inline_styles as st, components
 
@@ -30,14 +32,14 @@ def on_lock_switch(lock):
         return st.active_lock, st.inactive_lock
 
 
-def export_data_as_csv(option, file_name):
-    if option == components.DownloadType.FILTERED.value:
-        exported_rows = "filteredAndSorted"
-    else:
-        exported_rows = "all"
+def export_data_as_csv(option, data, file_name):
+    df = pd.DataFrame(data)
 
+    exported_rows = "filteredAndSorted" if option == components.DownloadType.FILTERED.value else "all"
     # timestamp the file
     timestamp = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+    # post process the columns to have an underscore in lieu of the spaces
+    file = f"{file_name}_{exported_rows}_{timestamp}.csv"
 
-    # https://ag-grid.com/javascript-data-grid/csv-export/#reference-CsvExportParams-exportedRows
-    return True, {"fileName": f"{file_name}_{exported_rows}_{timestamp}.csv", "exportedRows": exported_rows}
+    # send the download to dash
+    return dcc.send_data_frame(df.to_csv, file)

--- a/snaptron_query/app/column_defs.py
+++ b/snaptron_query/app/column_defs.py
@@ -148,7 +148,7 @@ def get_col_jiq():
     return [
         {
             "field": gs.table_jiq_col_inc,
-            "headerName": "Inc_Count",
+            "headerName": "Inc Count",
             "filter": "agNumberColumnFilter",
             "width": 130,
             "filterParams": {
@@ -158,7 +158,7 @@ def get_col_jiq():
         },
         {
             "field": gs.table_jiq_col_exc,
-            "headerName": "Exc_Count",
+            "headerName": "Exc Count",
             "filter": "agNumberColumnFilter",
             "width": 130,
             "filterParams": {
@@ -168,7 +168,7 @@ def get_col_jiq():
         },
         {
             "field": gs.table_jiq_col_total,
-            "headerName": "Total_Count",
+            "headerName": "Total Count",
             "filter": "agNumberColumnFilter",
             "width": 160,
             "filterParams": {

--- a/snaptron_query/app/global_strings.py
+++ b/snaptron_query/app/global_strings.py
@@ -176,17 +176,17 @@ tcgav2_meta_data_required_list = [
 gtexv2_meta_data_required_list = [snpt_col_rail_id, "run_acc", snpt_col_study, "SEX", "AGE", "SAMPID", "SMTS", "SMTSD"]
 
 # JIQ
-table_jiq_col_inc = "inc"
-table_jiq_col_exc = "exc"
-table_jiq_col_total = "total"
+table_jiq_col_inc = "inc_count"
+table_jiq_col_exc = "exc_count"
+table_jiq_col_total = "total_count"
 table_jiq_col_psi = "psi"
-table_jiq_col_log_2 = "log2"
+table_jiq_col_log_2 = "log2_psi"
 table_jiq_col_avg_psi = "avg_psi"
 
 # GEQ
 table_geq_col_raw_count = "raw_count"
 table_geq_col_norm_count = "normalized_count"
 table_geq_col_factor = "factor"
-table_geq_col_log_2_norm = "log2_norm_count"
-table_geq_col_log_2_raw = "log2_raw"
+table_geq_col_log_2_norm = "log2_normalized_count"
+table_geq_col_log_2_raw = "log2_raw_count"
 dbc_template_name = "sandstone"

--- a/snaptron_query/app/main_dash_app.py
+++ b/snaptron_query/app/main_dash_app.py
@@ -72,6 +72,7 @@ app.layout = dbc.Container(
         # a space for log content if any
         dmc.Space(h=30),
         dcc.Store(id="id-store-jiq-junctions"),
+        dcc.Download(id="download-data-csv"),
     ],
     # TODO: Keep this commented here, need to verify with PI rep to switch to full width or not
     # fluid=True,  # this will make the page use full screen width
@@ -541,27 +542,43 @@ def update_box_plot_data(log_x, lock_with_table, normalized_count, virtual_row_d
 
 
 @app.callback(
-    Output("id-ag-grid-jiq", "exportDataAsCsv"),
-    Output("id-ag-grid-jiq", "csvExportParams"),
+    Output("download-data-csv", "data"),
     Input("id-button-jiq-download", "n_clicks"),
+    State("id-ag-grid-jiq", "virtualRowData"),
+    State("id-ag-grid-jiq", "rowData"),
     State("id-jiq-download-options", "value"),
     prevent_initial_call=True,
     running=[(Output("id-button-jiq-download", "disabled"), True, False)],  # requires the latest Dash 2.16
 )
-def export_data_as_csv_jiq(n_clicks, option):
-    return callback.export_data_as_csv(option, "psi_query_data")
+def export_data_as_csv_jiq(n_clicks, filtered_data, row_data, option):
+    if ctx.triggered_id == "id-button-jiq-download":
+        return callback.export_data_as_csv(
+            option=option,
+            data=filtered_data if option == components.DownloadType.FILTERED.value else row_data,
+            file_name="psi_query_data",
+        )
+    else:
+        raise PreventUpdate
 
 
 @app.callback(
-    Output("id-ag-grid-geq", "exportDataAsCsv"),
-    Output("id-ag-grid-geq", "csvExportParams"),
+    Output("download-data-csv", "data", allow_duplicate=True),
     Input("id-button-geq-download", "n_clicks"),
+    State("id-ag-grid-geq", "virtualRowData"),
+    State("id-ag-grid-geq", "rowData"),
     State("id-geq-download-options", "value"),
     prevent_initial_call=True,
     running=[(Output("id-button-geq-download", "disabled"), True, False)],  # requires the latest Dash 2.16
 )
-def export_data_as_csv_geq(n_clicks, option):
-    return callback.export_data_as_csv(option, "gene_expression_query_data")
+def export_data_as_csv_geq(n_clicks, filtered_data, row_data, option):
+    if ctx.triggered_id == "id-button-geq-download":
+        return callback.export_data_as_csv(
+            option=option,
+            data=filtered_data if option == components.DownloadType.FILTERED.value else row_data,
+            file_name="gene_expression_query_data",
+        )
+    else:
+        raise PreventUpdate
 
 
 @app.callback(

--- a/snaptron_query/app/query_junction_inclusion.py
+++ b/snaptron_query/app/query_junction_inclusion.py
@@ -6,8 +6,8 @@ from snaptron_query.app import exceptions, global_strings as gs, utils
 
 
 class JunctionType(StrEnum):
-    EXCLUSION = "exc"
-    INCLUSION = "inc"
+    EXCLUSION = gs.table_jiq_col_exc
+    INCLUSION = gs.table_jiq_col_inc
 
 
 class JiqReturnType(StrEnum):
@@ -38,7 +38,12 @@ def insert_junction_calculations(list_of_junctions, junction_index, dict_items_t
     if junction_index >= len(list_of_junctions):
         # Note: I purposefully did not fill the junction with JiqCalculations default.
         # All the other calculations are based upon these two values and are derived IF they exist for a junction
-        list_of_junctions.extend([{"inc": 0, "exc": 0} for _ in range(junction_index - len(list_of_junctions) + 1)])
+        list_of_junctions.extend(
+            [
+                {gs.table_jiq_col_inc: 0, gs.table_jiq_col_exc: 0}
+                for _ in range(junction_index - len(list_of_junctions) + 1)
+            ]
+        )
 
     # Update the dictionary in the first list at the given index
     list_of_junctions[junction_index].update(dict_items_to_add)
@@ -79,8 +84,12 @@ class JunctionInclusionQueryManager:
             # get the inclusion and exclusion counts for this junction index
             # if this sample does not show up at this junction index, it will be populated with default
             # values in the IndexError exception below
-            inclusion_count = (self.rail_id_dictionary[rail_id]["junctions"][junction_index]).get("inc", 0)
-            exclusion_count = (self.rail_id_dictionary[rail_id]["junctions"][junction_index]).get("exc", 0)
+            inclusion_count = (self.rail_id_dictionary[rail_id]["junctions"][junction_index]).get(
+                gs.table_jiq_col_inc, 0
+            )
+            exclusion_count = (self.rail_id_dictionary[rail_id]["junctions"][junction_index]).get(
+                gs.table_jiq_col_exc, 0
+            )
 
         except IndexError:
             # if rail id has no sample in the junction, populate with default values
@@ -142,7 +151,7 @@ class JunctionInclusionQueryManager:
         single_junction = []
         for rail_id, rail_data in self.rail_id_dictionary.items():
             if rail_data["meta"] and len(rail_data["junctions"]) == 1:
-                data = {"rail_id": rail_id}
+                data = {gs.snpt_col_rail_id: rail_id}
                 data.update(rail_data["meta"])
                 data.update(rail_data["junctions"][0])
                 single_junction.append(data)
@@ -209,8 +218,8 @@ class JunctionInclusionQueryManager:
             inclusion_junction_samples = (inc_junctions_df[gs.snpt_col_samples]).tolist()
 
             # Gather results in a dictionary
-            self._gather_samples_rail_id_and_counts(exclusion_junction_samples, "exc", junction_index)
-            self._gather_samples_rail_id_and_counts(inclusion_junction_samples, "inc", junction_index)
+            self._gather_samples_rail_id_and_counts(exclusion_junction_samples, gs.table_jiq_col_exc, junction_index)
+            self._gather_samples_rail_id_and_counts(inclusion_junction_samples, gs.table_jiq_col_inc, junction_index)
 
         # For each rail id found, gather its metadata and calculate PSI values
         # this will populate self.gathered_rail_id_meta_data_and_psi

--- a/snaptron_query/app/tests/test_jiq.py
+++ b/snaptron_query/app/tests/test_jiq.py
@@ -84,7 +84,7 @@ def test_jiq_results_size_cols(junction_srav3h):
 
 
 @pytest.mark.parametrize(
-    "rail_id,external_id,inc,exc,psi",
+    "rail_id,external_id,inc_count,exc_count,psi",
     [
         (1000010, "SRR3743424", 0, 11, 0.0),
         (2171668, "SRR5714918", 35, 0, 100.0),
@@ -97,16 +97,16 @@ def test_jiq_results_size_cols(junction_srav3h):
         (2109561, "SRR6873183", 12, 34, 26.09),
     ],
 )
-def test_jiq_results_srav3h(junction_srav3h, rail_id, external_id, inc, exc, psi):
+def test_jiq_results_srav3h(junction_srav3h, rail_id, external_id, inc_count, exc_count, psi):
     s = junction_srav3h.get_results().loc[rail_id]
     assert s[gs.snpt_col_external_id] == external_id
-    assert s[gs.table_jiq_col_inc] == inc
-    assert s[gs.table_jiq_col_exc] == exc
+    assert s[gs.table_jiq_col_inc] == inc_count
+    assert s[gs.table_jiq_col_exc] == exc_count
     assert s[gs.table_jiq_col_psi] == psi
 
 
 @pytest.mark.parametrize(
-    "rail_id,study,inc,exc,psi",
+    "rail_id,study,inc_count,exc_count,psi",
     [
         (2216416, "BLOOD", 2, 27, 6.9),
         (4399966, "LUNG", 2, 31, 6.06),
@@ -120,16 +120,16 @@ def test_jiq_results_srav3h(junction_srav3h, rail_id, external_id, inc, exc, psi
         (9783109, "MUSCLE", 2, 17, 10.53),
     ],
 )
-def test_jiq_results_gtexv2(junction_gtexv2, rail_id, study, inc, exc, psi):
+def test_jiq_results_gtexv2(junction_gtexv2, rail_id, study, inc_count, exc_count, psi):
     s = junction_gtexv2.get_results().loc[rail_id]
     assert s[gs.snpt_col_study] == study
-    assert s[gs.table_jiq_col_inc] == inc
-    assert s[gs.table_jiq_col_exc] == exc
+    assert s[gs.table_jiq_col_inc] == inc_count
+    assert s[gs.table_jiq_col_exc] == exc_count
     assert s[gs.table_jiq_col_psi] == psi
 
 
 @pytest.mark.parametrize(
-    "rail_id,study,inc,exc,psi",
+    "rail_id,study,inc_count,exc_count,psi",
     [
         (858212, "UCEC", 2, 18, 10.0),
         (220457, "CESC", 2, 21, 8.7),
@@ -142,16 +142,16 @@ def test_jiq_results_gtexv2(junction_gtexv2, rail_id, study, inc, exc, psi):
         (472121, "PRAD", 1, 19, 5.0),
     ],
 )
-def test_jiq_results_tcgav2(junction_tcgav2, rail_id, study, inc, exc, psi):
+def test_jiq_results_tcgav2(junction_tcgav2, rail_id, study, inc_count, exc_count, psi):
     s = junction_tcgav2.get_results().loc[rail_id]
     assert s[gs.snpt_col_study] == study
-    assert s[gs.table_jiq_col_inc] == inc
-    assert s[gs.table_jiq_col_exc] == exc
+    assert s[gs.table_jiq_col_inc] == inc_count
+    assert s[gs.table_jiq_col_exc] == exc_count
     assert s[gs.table_jiq_col_psi] == psi
 
 
 @pytest.mark.parametrize(
-    "rail_id,study,inc,exc,psi",
+    "rail_id,study,inc_count,exc_count,psi",
     [
         (3072016, "SRP057123", 21, 0, 100.0),
         (669879, "SRP061340", 40, 67, 37.38),
@@ -164,11 +164,11 @@ def test_jiq_results_tcgav2(junction_tcgav2, rail_id, study, inc, exc, psi):
         (2885781, "SRP124512", 6, 21, 22.22),
     ],
 )
-def test_jiq_results_srav1m(junction_srav1m, rail_id, study, inc, exc, psi):
+def test_jiq_results_srav1m(junction_srav1m, rail_id, study, inc_count, exc_count, psi):
     s = junction_srav1m.get_results().loc[rail_id]
     assert s[gs.snpt_col_study] == study
-    assert s[gs.table_jiq_col_inc] == inc
-    assert s[gs.table_jiq_col_exc] == exc
+    assert s[gs.table_jiq_col_inc] == inc_count
+    assert s[gs.table_jiq_col_exc] == exc_count
     assert s[gs.table_jiq_col_psi] == psi
 
 


### PR DESCRIPTION
Data headers needed to use underscore and original strings when downloaded instead of the aliases used in the table. I am  switching the code to use dcc.download and a dataframe instead of the aggrid download api which didn't allow a runtime change to the header names just for download.