### PR TITLE
fixing plot height

### DIFF
--- a/snaptron_query/app/layout_jiq.py
+++ b/snaptron_query/app/layout_jiq.py
@@ -254,6 +254,7 @@ def get_card_box_plot_jiq():
                                 className="d-flex justify-content-start",
                                 align="center",
                                 style=styles.border_column,
+                                width=1,
                             ),
                             dbc.Col(
                                 [


### PR DESCRIPTION
This PR fixes the the plot height issue.
Setting the width of the first column allows the other text to flow left and fix the height issue.
