### PR TITLE
Clearing alerts when new query is requested

### DIFF
--- a/snaptron_query/app/main_dash_app.py
+++ b/snaptron_query/app/main_dash_app.py
@@ -181,6 +181,7 @@ def on_button_click_jiq_run(
 
 
 @app.callback(
+    Output("id-alert-jiq", "children", allow_duplicate=True),
     Output("id-display-ag-grid-jiq", "style", allow_duplicate=True),
     Output("id-display-graphs-jiq", "style", allow_duplicate=True),
     Output("id-results-cleared-jiq", "data", allow_duplicate=True),
@@ -192,6 +193,7 @@ def on_button_click_jiq_run(
 def on_button_click_jiq_clear(n_clicks, results_are_cleared):
     if ctx.triggered_id == "id-button-jiq-generate-results" and not results_are_cleared:
         return (  # clear everything
+            [],  # clear alert if any
             styles.display_none,  # grid display
             styles.display_none,  # graph display
             True,
@@ -526,6 +528,7 @@ def on_button_click_geq_run(
 
 
 @app.callback(
+    Output("id-alert-geq", "children", allow_duplicate=True),
     Output("id-display-ag-grid-geq", "style", allow_duplicate=True),
     Output("id-display-graphs-geq", "style", allow_duplicate=True),
     Output("id-results-cleared-geq", "data", allow_duplicate=True),
@@ -537,6 +540,7 @@ def on_button_click_geq_run(
 def on_button_click_geq_clear(n_clicks, results_are_cleared):
     if ctx.triggered_id == "id-button-geq-run-query" and not results_are_cleared:
         return (  # clear everything
+            [],  # clear alert if any
             styles.display_none,  # grid display
             styles.display_none,  # graph display
             True,

--- a/snaptron_query/app/tests/test_callbacks_2.py
+++ b/snaptron_query/app/tests/test_callbacks_2.py
@@ -36,9 +36,10 @@ def test_on_button_click_jiq_clear(monkeypatch_meta_data):
 
     ctx = copy_context()
     output = ctx.run(run_callback)
-    assert output[0] == inline_styles.display_none
+    assert output[0] == []
     assert output[1] == inline_styles.display_none
-    assert output[2]
+    assert output[2] == inline_styles.display_none
+    assert output[3]
 
 
 def test_on_button_click_jiq_clear_error(monkeypatch_meta_data):
@@ -72,9 +73,10 @@ def test_on_button_click_geq_clear(monkeypatch_meta_data):
 
     ctx = copy_context()
     output = ctx.run(run_callback)
-    assert output[0] == inline_styles.display_none
+    assert output[0] == []
     assert output[1] == inline_styles.display_none
-    assert output[2]
+    assert output[2] == inline_styles.display_none
+    assert output[3]
 
 
 def test_on_button_click_geq_clear_error(monkeypatch_meta_data):


### PR DESCRIPTION
This PR closes issue #163 
Alerts were stale and did not clear when requesting a new query. 