### PR TITLE
Resolve #238: Warning for junction coordinates

### DIFF
--- a/snaptron_query/app/components.py
+++ b/snaptron_query/app/components.py
@@ -222,3 +222,12 @@ def get_info_icon_tooltip_bundle(info_icon_id, help_string, location):
     return html.Div(
         [dmc.Text(icons.info, id=info_icon_id, weight=500, size="md"), get_tooltip(info_icon_id, help_string, location)]
     )
+
+
+def get_caution_icon_tooltip_bundle(caution_icon_id, help_string, location):
+    return html.Div(
+        [
+            dmc.Text(icons.caution, id=caution_icon_id, weight=500, size="md"),
+            get_tooltip(caution_icon_id, help_string, location),
+        ]
+    )

--- a/snaptron_query/app/global_strings.py
+++ b/snaptron_query/app/global_strings.py
@@ -130,6 +130,10 @@ jiq_help_excjunc = (
 jiq_help_table = f" Table initially loads with PSI\u2265{const_filter_psi} and Total\u2265{const_filter_total}."
 jiq_help_add_junction = "Add more inclusion or exclusion junctions (up to 5) to the PSI query"
 jiq_help_delete_junction = "Remove junction from the PSI query"
+jiq_caution = (
+    "We strongly recommend users cross-validate junction coordinates using visualization tools like UCSC "
+    "Genome Browser or IGV. "
+)
 
 """""" """""" """""" """""" """""" """""" """""" """""" """""" """""" """
             Gene Expression Query 

--- a/snaptron_query/app/icons.py
+++ b/snaptron_query/app/icons.py
@@ -8,7 +8,9 @@ del_box = html.I(DashIconify(icon="mdi:minus-box", height=SMALL, width=SMALL))
 download = html.I(DashIconify(icon="mdi:tray-download", height=MEDIUM, width=MEDIUM))
 reset = html.I(DashIconify(icon="mdi:filter-remove", height=MEDIUM, width=MEDIUM))
 info = html.I(DashIconify(icon="fa6-solid:circle-info", height=SMALL, width=SMALL), style={"color": "var(--bs-info)"})
-caution = html.I(DashIconify(icon="fluent:warning-32-filled", height=SMALL, width=SMALL), style={"color": "#e38e23"})
+caution = html.I(
+    DashIconify(icon="fa6-solid:triangle-exclamation", height=SMALL, width=SMALL), style={"color": "var(--bs-warning)"}
+)
 
 
 def get_lock_opened(icon_id):

--- a/snaptron_query/app/icons.py
+++ b/snaptron_query/app/icons.py
@@ -8,6 +8,7 @@ del_box = html.I(DashIconify(icon="mdi:minus-box", height=SMALL, width=SMALL))
 download = html.I(DashIconify(icon="mdi:tray-download", height=MEDIUM, width=MEDIUM))
 reset = html.I(DashIconify(icon="mdi:filter-remove", height=MEDIUM, width=MEDIUM))
 info = html.I(DashIconify(icon="fa6-solid:circle-info", height=SMALL, width=SMALL), style={"color": "var(--bs-info)"})
+caution = html.I(DashIconify(icon="fluent:warning-32-filled", height=SMALL, width=SMALL), style={"color": "#e38e23"})
 
 
 def get_lock_opened(icon_id):

--- a/snaptron_query/app/layout_jiq.py
+++ b/snaptron_query/app/layout_jiq.py
@@ -52,6 +52,9 @@ def get_form_jiq():
                                 components.get_info_icon_tooltip_bundle(
                                     "id-info-inc-junc-jiq", gs.jiq_help_incjunc, "top"
                                 ),
+                                components.get_caution_icon_tooltip_bundle(
+                                    "id-caution-inc-junc-jiq", gs.jiq_caution, "top"
+                                ),
                             ],
                             style={"display": "flex", "gap": "5px"},
                         )
@@ -68,6 +71,9 @@ def get_form_jiq():
                                 components.get_text(gs.jiq_input_exc_txt),
                                 components.get_info_icon_tooltip_bundle(
                                     "id-info-exc-junc-jiq", gs.jiq_help_excjunc, "top"
+                                ),
+                                components.get_caution_icon_tooltip_bundle(
+                                    "id-caution-exc-junc-jiq", gs.jiq_caution, "top"
                                 ),
                             ],
                             style={"display": "flex", "gap": "5px"},

--- a/snaptron_query/app/tests/test_misc.py
+++ b/snaptron_query/app/tests/test_misc.py
@@ -131,6 +131,10 @@ def test_get_info_icon_tooltip_bundle():
     assert isinstance(components.get_info_icon_tooltip_bundle("id", "string", "location"), html.Div)
 
 
+def test_get_caution_icon_tooltip_bundle():
+    assert isinstance(components.get_caution_icon_tooltip_bundle("id", "string", "location"), html.Div)
+
+
 def test_empty_inc_junction():
     assert exceptions.EmptyIncJunction(2).get_message().find("Inclusion Junction 2") != -1
 


### PR DESCRIPTION
Resolve #238

- Add "caution" icon to icons
- Add "caution" tool-tip function to components
- Add gs as requested
- Add "caution" icon with warning to jiq layout
- Create test for caution tool-tip function